### PR TITLE
maintain gameType after game end

### DIFF
--- a/main.asm
+++ b/main.asm
@@ -3883,14 +3883,14 @@ playState_bTypeGoalCheck:
 @graphicCopied:  lda     #$00
         sta     vramRow
         jsr     sleep_for_14_vblanks
-        lda     #$00
-        sta     renderMode
         lda     #$80
         jsr     sleep_for_a_vblanks
         jsr     endingAnimation_maybe
         lda     #$00
         sta     playState
         inc     gameModeState
+        lda     #$04
+        sta     renderMode
         rts
 
 @ret:  inc     playState


### PR DESCRIPTION
renderMode set to 0 was causing tiles to be drawn on the board, as well as resetting gameType in the render function. 