### PR TITLE
Bugfix: Game can softlock after resetting

### DIFF
--- a/main.asm
+++ b/main.asm
@@ -187,6 +187,15 @@ highScoreScoresA:= $0730
 highScoreScoresB:= $073C
 highScoreLevels := $0748
 initMagic       := $0750                        ; Initialized to a hard-coded number. When resetting, if not correct number then it knows this is a cold boot
+backupSubFrameTop := $0755
+backupPollsPerFrame := $0756
+backupStartLevel := $0757
+backupStartLevelTens := $0758
+backupStartLevelOnes := $0759
+backupStartHeight := $075A
+backupMusicType := $075B
+backupGameType := $075C
+
 PPUCTRL         := $2000
 PPUMASK         := $2001
 PPUSTATUS       := $2002
@@ -246,6 +255,25 @@ render: lda     renderMode
         .addr   render_mode_play_and_demo
         .addr   render_mode_ending_animation
 initRamContinued:
+        ; before we clear everything out, there are a few values we want saved across resets.
+        ; we will preserve them, even if this is a cold boot, just to make life easier. - mathmaster13
+        lda     subFrameTop
+        sta     backupSubFrameTop
+        lda     pollsPerFrame
+        sta     backupPollsPerFrame
+        lda     startLevel
+        sta     backupStartLevel
+        lda     startLevelTens
+        sta     backupStartLevelTens
+        lda     startLevelOnes
+        sta     backupStartLevelOnes
+        lda     startHeight
+        sta     backupStartHeight
+        lda     gameType
+        sta     backupGameType
+        lda     musicType
+        sta     backupMusicType
+        ; now we can zero everything out
         ldy     #$06
         sty     tmp2
         ldy     #$00
@@ -272,6 +300,25 @@ initRamContinued:
         lda     initMagic+4
         cmp     #$9A
         bne     @initHighScoreTable
+        
+        ; at this point, we know we're in a warm boot, so let's reload those missing menu values - mathmaster13
+        lda     backupSubFrameTop
+        sta     subFrameTop
+        lda     backupPollsPerFrame
+        sta     pollsPerFrame
+        lda     backupStartLevel
+        sta     startLevel
+        lda     backupStartLevelTens
+        sta     startLevelTens
+        lda     backupStartLevelOnes
+        sta     startLevelOnes
+        lda     backupStartHeight
+        sta     startHeight
+        lda     backupGameType
+        sta     gameType
+        lda     backupMusicType
+        sta     musicType
+        
         jmp     @continueWarmBootInit
 
         ldx     #$00

--- a/main.asm
+++ b/main.asm
@@ -256,7 +256,7 @@ render: lda     renderMode
         .addr   render_mode_ending_animation
 initRamContinued:
         ; before we clear everything out, there are a few values we want saved across resets.
-        ; we will preserve them, even if this is a cold boot, just to make life easier. - mathmaster13
+        ; we will preserve them, even if this is a cold boot, just to make life easier.
         lda     subFrameTop
         sta     backupSubFrameTop
         lda     pollsPerFrame
@@ -301,7 +301,7 @@ initRamContinued:
         cmp     #$9A
         bne     @initHighScoreTable
         
-        ; at this point, we know we're in a warm boot, so let's reload those missing menu values - mathmaster13
+        ; at this point, we know we're in a warm boot, so let's reload those missing menu values
         lda     backupSubFrameTop
         sta     subFrameTop
         lda     backupPollsPerFrame

--- a/tetris-ram.asm
+++ b/tetris-ram.asm
@@ -197,3 +197,11 @@ highScoreScoresA:	.res $C	; $0730
 highScoreScoresB:	.res $C	; $073C
 highScoreLevels:	.res $08	; $0748
 initMagic:	.res $05	; $0750
+backupSubFrameTop:   .res $01 ; $0755
+backupPollsPerFrame:   .res $01 ; $0756
+backupStartLevel:   .res $01 ; $0757
+backupStartLevelTens:   .res $01 ; $0758
+backupStartLevelOnes:   .res $01 ; $0759
+backupStartHeight:    .res $01 ; $075A
+backupMusicType:    .res $01 ; $075B
+backupGameType:    .res $01 ; $075C


### PR DESCRIPTION
Hi! This bug personally drives me nuts. I understand that speedhack is old and it's okay if you don't want to be bothered with this, but I thought I'd try just in case.

Upon resetting the game, every menu value is set to zero, even though the code looks like it intends to preserve previous menu values. In particular, the speed is set to 0/0, and the game softlocks if we accidentally select this speed. I have done this to myself, many times.

I tested the fix for a little bit and there seem to be no regressions from speedhack. But this is my first time with NES programming.

Why this happens: the original ROM (and also speedhack) runs `@zeroOutPages`. Speedhack stores the menu choices in the region that gets zeroed out, and so it all gets cleared. Since the affected menu items are a small number of bytes and not one contiguous string of bytes, I decided to just back up these menu items to an unused part of memory, zero out everything just like the vanilla ROM, and then restore the menu items afterward.

Side note: I know of another bug in speedhack/PALhack—namely, the rocket screen music stops early and refuses to loop, or in some cases even plays garbage audio. I can try to look at this after finals week, but I wanted to send the 0/0 bugfix over in the meantime. The level, height, A/B-type, and/or speed may have an effect on the garbage audio; I need to do further testing to find out the exact cause. This PR does not cause the garbage audio, but *does* change what audio is heard. The point at which the music stops is also different on my (currently in progress, possibly broken) PAL version of speedhack.